### PR TITLE
Add manual trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,13 @@
-# .github/workflows/release.yml
 name: Release Automation
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [closed]
     branches: [development]
 
 jobs:
   release:
-    # Solo corre si el PR fue mergeado (no si fue cerrado sin merge)
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## 📋 Summary
This PR adds the `workflow_dispatch` trigger to the release automation workflow, allowing manual execution in addition to the existing automatic trigger on PR merges.

## 🎯 Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] Build system changes
- [x] CI/CD changes

## 🔍 What Changed
### Added
- `workflow_dispatch` trigger to release automation workflow

### Changed
- Workflow trigger logic to include manual execution option

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All tests passing

**Test Instructions:**  
1. Manually trigger workflow via GitHub Actions UI
2. Verify workflow executes correctly
3. Merge test PR to development branch
4. Verify workflow triggers automatically

## ✅ Checklist
- [x] Follows project style guidelines
- [x] Self-reviewed my code
- [x] Commented complex logic
- [ ] Updated documentation
- [x] No new warnings
- [x] Existing and new tests pass locally