### PR TITLE
ci(release): add workflow_dispatch trigger to release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     types: [closed]
-    branches: [development]
+    branches: [develop]
 
 jobs:
   release:


### PR DESCRIPTION
Allows manually triggering the release workflow in addition to automatic trigger on PR merges to development branch.