### PR TITLE
ci(release): simplify PR approval check in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,10 @@ jobs:
             const { data: reviews } = await github.rest.pulls.listReviews({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: ${{ github.event.pull_request.number }}
+              pull_number: ${{ steps.set_pr_number.outputs.pr_number }}
             })
 
-            // Check for at least one APPROVED review
-            const hasApproval = reviews.some(review =>
-              review.state === 'APPROVED' &&
-              review.commit_id === github.event.pull_request.head.sha
-            )
+            const hasApproval = reviews.some(review => review.state === 'APPROVED')
 
             if (!hasApproval) {
               core.setFailed('❌ PR has not been approved')


### PR DESCRIPTION
Removed commit_id check from PR approval verification to make the approval process less strict and more straightforward.

BREAKING CHANGE: PR approvals are now checked without verifying the commit_id matches the PR head SHA.