### PR TITLE
Add PR info retrieval to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,6 @@ on:
         description: 'Pull Request number to process'
         required: true
         type: number
-      pr_title:
-        description: 'PR Title (optional)'
-        required: false
-        type: string
   pull_request_review:
     branches: [develop]
     types: [submitted]
@@ -40,6 +36,28 @@ jobs:
           else
             echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           fi
+
+      - name: 'Get PR Information'
+        id: get_pr_info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ steps.set_pr_number.outputs.pr_number }}
+            })
+
+            console.log('PR Title:', pr.title)
+            console.log('PR Body:', pr.body ? 'Present' : 'Empty')
+
+            core.setOutput('pr_title', pr.title)
+            core.setOutput('pr_body', pr.body || '')
+
+            return {
+              title: pr.title,
+              body: pr.body || ''
+            }
 
       - name: 'Verify PR Approval Status'
         if: github.event_name == 'pull_request_review'
@@ -80,6 +98,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ steps.set_pr_number.outputs.pr_number }}
+          PR_TITLE: ${{ steps.get_pr_info.outputs.pr_title }}
+          PR_BODY: ${{ steps.get_pr_info.outputs.pr_body }}
         run: node .github/scripts/auto-version.script.js
 
       - name: 'Commit and Push Changes'


### PR DESCRIPTION
## 📋 Summary
Enhanced release workflow to fetch PR title and body automatically instead of requiring manual input.

## 🎯 Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] Build system changes
- [x] CI/CD changes

## 🔍 What Changed
### Added
- New step to fetch PR title and body using github-script
- Environment variables for PR title and body in version script

### Changed
- Updated workflow to use auto-fetched PR info

### Removed
- Deprecated pr_title input parameter

## 🧪 Testing
- [x] Manual testing completed

**Test Instructions:**
1. Create a test PR with title and body
2. Trigger the release workflow
3. Verify PR info is correctly passed to version script

## ✅ Checklist
- [x] Follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing and new tests pass locally