### PR TITLE
Update Redis secret path and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -781,6 +781,7 @@ FodyWeavers.xsd
 
 ### Project Specific Additions ###
 .secrets
+scripts/backups-secrets.script.js
 
 # Custom project folders and files
 sync_models/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 
 
+## [1.14.3] - 2025-10-13
+
+**Released:** 2025-10-13 22:43:42 UTC
+
+### [Update Redis secret path and gitignore](https://github.com/Santiago1010/node-template/pull/66)
+
+#### 📋 Summary
+Update Redis configuration to use new secret path and add backup script to gitignore
+
+#### 🔍 What Changed
+### Changed
+- Redis secret path from 'redis' to 'cache/redis' in configuration
+- Updated .gitignore to exclude scripts/backups-secrets.script.js
+
+**Details:**
+- Author: [@Santiago1010](https://github.com/Santiago1010)
+- Approved by: [@Sleon4](https://github.com/Sleon4)
+- Labels: security
+- Commits: 1
+
+**Commits:**
+- [`55113c0`](https://github.com/Santiago1010/node-template/commit/55113c032b8f57b8abb3ff1f62780c43ece39beb) chore(config): update redis secret path and gitignore
+
+---
+
+
+
 ## [1.14.2] - 2025-10-13
 
 **Released:** 2025-10-13 19:47:39 UTC

--- a/config/cache/redis.config.js
+++ b/config/cache/redis.config.js
@@ -120,7 +120,7 @@ class RedisClient {
    */
   async connect() {
     try {
-      const vaultSecrets = await getSecret('redis', 'password');
+      const vaultSecrets = await getSecret('cache/redis', 'password');
 
       const config = {
         url: `redis://${redis.host}:${redis.port}`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-template",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "",
   "keywords": [
     "template",


### PR DESCRIPTION
## 📋 Summary
Update Redis configuration to use new secret path and add backup script to gitignore

## 🎯 Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [x] Build system changes
- [ ] CI/CD changes

## 🔍 What Changed
### Changed
- Redis secret path from 'redis' to 'cache/redis' in configuration
- Updated .gitignore to exclude scripts/backups-secrets.script.js

## 🧪 Testing
- [x] Manual testing completed
- [x] All tests passing

**Test Instructions:**  
1. Verify Redis connection establishes successfully with new secret path
2. Confirm backups-secrets.script.js is excluded from version control

## ✅ Checklist
- [x] Follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing and new tests pass locally